### PR TITLE
Add step hook to the executor

### DIFF
--- a/src/executor/stack.rs
+++ b/src/executor/stack.rs
@@ -14,8 +14,8 @@ use crate::gasometer::{self, Gasometer};
 pub trait RuntimeStepHook<'backend, 'config, B, H> {
 	fn step_hook(
 		&mut self,
-		executor: &mut StackExecutor<'backend, 'config, B, H>,
-		runtime: &mut Runtime
+		executor: &StackExecutor<'backend, 'config, B, H>,
+		runtime: &Runtime
 	);
 }
 
@@ -25,8 +25,8 @@ pub struct NoRuntimeStepHook {}
 impl<'backend, 'config, B, H> RuntimeStepHook<'backend, 'config, B, H> for NoRuntimeStepHook {
 	fn step_hook(
 		&mut self,
-		_executor: &mut  StackExecutor<'backend, 'config, B, H>,
-		_runtime: &mut Runtime
+		_executor: &StackExecutor<'backend, 'config, B, H>,
+		_runtime: &Runtime
 	) {
 
 	}


### PR DESCRIPTION
Adds a new `Hook` trait allowing to hook into the stepping of the executor.

To avoid any API breaking :
- `Hook` is stored in an option in the `StackExecutor`, and a new function is added to change the hook.
- By default, a `NoHook` is used which does nothing. This should be compiled and optimized to the same binary as before when used.