### PR TITLE
Expose origin in precompile handle

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -1595,6 +1595,11 @@ impl<'inner, 'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Pr
 		self.context
 	}
 
+	/// Retreive the address of the EOA that originated the transaction.
+	fn origin(&self) -> H160 {
+		self.executor.state.origin()
+	}
+
 	/// Is the precompile call is done statically.
 	fn is_static(&self) -> bool {
 		self.is_static

--- a/src/executor/stack/precompile.rs
+++ b/src/executor/stack/precompile.rs
@@ -76,6 +76,9 @@ pub trait PrecompileHandle {
 	/// Retreive the context in which the precompile is executed.
 	fn context(&self) -> &Context;
 
+	/// Retreive the address of the EOA that originated the transaction.
+	fn origin(&self) -> H160;
+
 	/// Is the precompile call is done statically.
 	fn is_static(&self) -> bool;
 


### PR DESCRIPTION
Exposes the transaction origin in precompile handle, this can be used to identify if the caller is an Externally Owner Account (EOA).